### PR TITLE
Configurable transfer_size on SPI writes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,10 +4,11 @@ ChangeLog
 +------------+---------------------------------------------------------------------+------------+
 | Version    | Description                                                         | Date       |
 +============+=====================================================================+============+
-| *Upcoming* | *TBC*                                                               |            |
+| *Upcoming* | * Configurable ``transfer_size`` on SPI writes                      |            |
+|            | * Documentation updates                                             |            |
 +------------+---------------------------------------------------------------------+------------+
 | **0.1.14** | * Use a more flexible no-op implementation                          | 2017/02/03 |
-|            | * Use spidev's writebytes() rather than xfer2()                     |            |
+|            | * Use spidev's ``writebytes()`` rather than ``xfer2()``             |            |
 |            | * Dont write GIF animation if nothing was displayed                 |            |
 |            | * Attempt to optimize palette when saving GIF animations            |            |
 +------------+---------------------------------------------------------------------+------------+


### PR DESCRIPTION
py-spidev on RPi supports a transfer size of 4096 bytes - this was previously hardcoded in spi.py, but other devices have a smaller transfer buffer, notably either 64 or 128 bytes. 

This PR allows the default of 4096 to be overridden when the SPI interface is initiated.