### PR TITLE
Add full-frame and diff-to-previous framebuffer implementations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ ChangeLog
 | Version    | Description                                                         | Date       |
 +============+=====================================================================+============+
 | *Upcoming* | * Add spritesheet and framerate_regulator functionality             |            |
+|            | * Add full-frame and diff-to-previous framebuffer implementations   |            |
+|            | * Remove unnecessary travis/tox dependencies                        |            |
 +------------+---------------------------------------------------------------------+------------+
 | **0.3.2*** | * Bug fix: ``legacy.show_message`` wrong device height              | 2017/02/24 |
 |            | * Add Cyrillic chars to legacy font                                 |            |

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,9 @@ single board computers:
 * terminal-style printing,
 * state management,
 * color/greyscale (where supported),
-* dithering to monochrome
+* dithering to monochrome,
+* sprite animation,
+* flexible framebuffering (depending on device capabilities)
 
 Device drivers extend **luma.core** to provide the correct initialization 
 sequences for specific physical display devices/chipsets.

--- a/doc/api-documentation.rst
+++ b/doc/api-documentation.rst
@@ -23,6 +23,13 @@ API Documentation
     :undoc-members:
     :show-inheritance:
 
+:mod:`luma.core.framebuffer`
+""""""""""""""""""""""""""""
+.. automodule:: luma.core.framebuffer
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 :mod:`luma.core.legacy`
 """""""""""""""""""""""
 .. automodule:: luma.core.legacy

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -9,7 +9,9 @@ single board computers:
 * terminal-style printing,
 * state management,
 * color/greyscale (where supported),
-* dithering to monochrome
+* dithering to monochrome,
+* sprite animation,
+* flexible framebuffering (depending on device capabilities)
 
 Device drivers extend **luma.core** to provide the correct initialization 
 sequences for specific physical display devices/chipsets.

--- a/luma/core/framebuffer.py
+++ b/luma/core/framebuffer.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2014-17 Richard Hull and contributors
+# See LICENSE.rst for details.
+
+"""
+Different implementation strategies for framebuffering
+"""
+
+from PIL import Image, ImageChops
+
+
+class diff_to_previous(object):
+    """
+    Compare the current frame to the previous frame and tries to calculate the
+    differences: this will either be ``None`` for a perfect match or some
+    bounding box describing the areas that are different, upto the size of the
+    entire image.
+
+    The image data for the difference is then be passed to a device for
+    rendering just those small changes. This can be very quick for small screen
+    updates, but suffers from variable render times, depending on the changes
+    applied. The :py:class`luma.core.sprite_system.framerate_regulator` may be
+    used to counteract this behviour however.
+
+    :param device: the target device, used to determine the initial 'previous'
+        image.
+    :type device: luma.core.device.device
+    """
+    def __init__(self, device):
+        self.image = Image.new(device.mode, device.size, "white")
+
+    def update(self, image):
+        """
+        Calculates the difference from the previous image, setting ``bbox`` and
+        ``image`` attributes, and priming :py:func:`getdata`.
+
+        :param image: An image to render
+        :type image: PIL.Image.Image
+        """
+        self.bbox = ImageChops.difference(self.image, image).getbbox()
+        if self.bbox is not None:
+            self.image = image.copy()
+
+    def getdata(self):
+        """
+        A sequence of pixel data relating to the changes that occurred
+        since the last time :py:func:`update` was last called.
+
+        :returns: A sequence of pixels
+        """
+        return self.image.crop(self.bbox).getdata() if self.bbox else []
+
+
+class full_frame(object):
+    """
+    Always renders the full frame every time. This is slower than
+    :py:class:`diff_to_previous` as there are generally more
+    pixels to update on every render, but it has a more consistent render time.
+    Not all display drivers may be able to use the differencing framebuffer, so
+    this is provided as a drop-in replacement.
+
+    :param device: the target device, used to determine the bounding box.
+    :type device: luma.core.device.device
+    """
+    def __init__(self, device):
+        self.bbox = (0, 0, device.width, device.height)
+
+    def update(self, image):
+        """
+        Caches the image ready for getting the sequence of pixel data with
+        :py:func:`getdata`.
+
+        :param image: An image to render
+        :type image: PIL.Image.Image
+        """
+        self.image = image
+
+    def getdata(self):
+        """
+        A sequence of pixels representing the full image supplied to the
+        :py:func:`update` method.
+
+        :returns: A sequence of pixels
+        """
+        return self.image.getdata()

--- a/tests/test_framebuffer.py
+++ b/tests/test_framebuffer.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2017 Richard Hull and contributors
+# See LICENSE.rst for details.
+
+from PIL import Image, ImageDraw
+from luma.core.device import dummy
+from luma.core.framebuffer import full_frame, diff_to_previous
+
+
+im1 = Image.new("1", (4, 4))
+draw = ImageDraw.Draw(im1)
+draw.line((0, 0) + (3, 0), fill="white")
+
+im2 = Image.new("1", (4, 4))
+draw = ImageDraw.Draw(im2)
+draw.line((0, 0) + (3, 0), fill="white")
+draw.line((0, 0) + (0, 3), fill="white")
+
+device = dummy(width=4, height=4, mode="1")
+
+
+def test_full_frame():
+    framebuffer = full_frame(device)
+    framebuffer.update(im1)
+    pix1 = list(framebuffer.getdata())
+    assert len(pix1) == 16
+    assert pix1 == [0xFF] * 4 + [0x00] * 12
+    assert framebuffer.bbox == (0, 0, 4, 4)
+
+    framebuffer.update(im2)
+    pix2 = list(framebuffer.getdata())
+    assert len(pix2) == 16
+    assert pix2 == [0xFF] * 4 + [0xFF, 0x00, 0x00, 0x00] * 3
+    assert framebuffer.bbox == (0, 0, 4, 4)
+
+    framebuffer.update(im2)
+    pix3 = list(framebuffer.getdata())
+    assert len(pix3) == 16
+    assert pix3 == [0xFF] * 4 + [0xFF, 0x00, 0x00, 0x00] * 3
+    assert framebuffer.bbox == (0, 0, 4, 4)
+
+
+def test_diff_to_previous():
+    framebuffer = diff_to_previous(device)
+    framebuffer.update(im1)
+    pix1 = list(framebuffer.getdata())
+    assert len(pix1) == 12
+    assert pix1 == [0x00] * 12
+    assert framebuffer.bbox == (0, 1, 4, 4)
+
+    framebuffer.update(im2)
+    pix2 = list(framebuffer.getdata())
+    assert len(pix2) == 3
+    assert pix2 == [0xFF] * 3
+    assert framebuffer.bbox == (0, 1, 1, 4)
+
+    framebuffer.update(im2)
+    pix3 = list(framebuffer.getdata())
+    assert len(pix3) == 0
+    assert framebuffer.bbox is None


### PR DESCRIPTION
This is an enabler, and other functionality to follow in specific
device implementations, notably SSD1331, SSD1322, SSD1325 - which
should see improved render performance with the ‘diff_to_previous’
frame buffer