### PR TITLE
Conditional install_deps for wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@
 
 import os
 import sys
-import platform
 from setuptools import setup
 
 
@@ -28,13 +27,10 @@ test_deps = [
 install_deps = [
     'pillow>=4.0.0',
     'smbus2',
-    'monotonic;python_version<"3.3"'
+    'monotonic;python_version<"3.3"',
+    'spidev;platform_system=="Linux"',
+    'RPI.GPIO;platform_system=="Linux"'
 ]
-
-
-if platform.system() not in ['Darwin', 'Windows']:
-    rpi_deps = ['spidev', 'RPI.GPIO']
-    install_deps.extend(rpi_deps)
 
 setup(
     name="luma.core",


### PR DESCRIPTION
Metadata now contains platform system directives:

```
Requires-Dist: pillow (>=4.0.0)
Requires-Dist: smbus2
Requires-Dist: RPI.GPIO; platform_system == "Linux"
Requires-Dist: spidev; platform_system == "Linux"
Requires-Dist: monotonic; python_version < "3.3"
Provides-Extra: docs
Requires-Dist: sphinx (>=1.5.1); extra == 'docs'
Provides-Extra: qa
Requires-Dist: flake8; extra == 'qa'
Requires-Dist: rstcheck; extra == 'qa'
Provides-Extra: test
Requires-Dist: pytest (>=3.1); extra == 'test'
Requires-Dist: pytest-cov; extra == 'test'
Provides-Extra: test
Requires-Dist: mock; python_version < "3.3" and extra == 'test'
```

See also: 
* https://github.com/rm-hull/luma.examples/issues/59
* https://github.com/rm-hull/luma.core/pull/97