### PR TITLE
Fix for Issue #124

### DIFF
--- a/luma/core/cmdline.py
+++ b/luma/core/cmdline.py
@@ -155,6 +155,7 @@ class make_serial(object):
                    device=self.opts.spi_device,
                    bus_speed_hz=self.opts.spi_bus_speed,
                    cs_high=self.opts.spi_cs_high,
+                   transfer_size=self.opts.spi_transfer_size,
                    gpio_DC=self.opts.gpio_data_command,
                    gpio_RST=self.opts.gpio_reset,
                    gpio=self.gpio or GPIO)
@@ -232,6 +233,8 @@ def create_parser(description):
     spi_group.add_argument('--spi-device', type=int, default=0, help='SPI device')
     spi_group.add_argument('--spi-bus-speed', type=int, default=8000000, help='SPI max bus speed (Hz)')
     spi_group.add_argument('--spi-cs-high', type=bool, default=False, help='SPI chip select is high')
+    spi_group.add_argument('--spi-transfer-size', type=int, default=4096, help='SPI bus max transfer unit (bytes)')
+
 
     gpio_group = parser.add_argument_group('GPIO')
     gpio_group.add_argument('--gpio', type=str, default=None, help='Alternative RPi.GPIO compatible implementation (SPI devices only)')

--- a/luma/core/cmdline.py
+++ b/luma/core/cmdline.py
@@ -235,7 +235,6 @@ def create_parser(description):
     spi_group.add_argument('--spi-cs-high', type=bool, default=False, help='SPI chip select is high')
     spi_group.add_argument('--spi-transfer-size', type=int, default=4096, help='SPI bus max transfer unit (bytes)')
 
-
     gpio_group = parser.add_argument_group('GPIO')
     gpio_group.add_argument('--gpio', type=str, default=None, help='Alternative RPi.GPIO compatible implementation (SPI devices only)')
     gpio_group.add_argument('--gpio-mode', type=str, default=None, help='Alternative pin mapping mode (SPI devices only)')

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -26,6 +26,7 @@ class test_spi_opts(object):
     spi_device = 0
     spi_bus_speed = 8000000
     spi_cs_high = False
+    spi_transfer_size = 4096
     gpio_data_command = 24
     gpio_reset = 25
     gpio_backlight = 18


### PR DESCRIPTION
Added command line argument that allows the maximum transfer unit for SPI to be adjusted.

Included the new configurable `spi_transfer_size` field within the `test_spi_opts` class for the command line argument parser module.