### PR TITLE
Optional "persist on exit"

### DIFF
--- a/luma/core/device.py
+++ b/luma/core/device.py
@@ -78,7 +78,7 @@ class device(mixin.capabilities):
         helps prolong the life of the device), clear the screen and close
         resources associated with the underlying serial interface.
 
-        If self.persist is True, the device will not be switched off.
+        If :py:attr:`persist` is True, the device will not be switched off.
 
         This is a managed function, which is called when the python processs
         is being shutdown, so shouldn't usually need be called directly in

--- a/luma/core/device.py
+++ b/luma/core/device.py
@@ -78,12 +78,15 @@ class device(mixin.capabilities):
         helps prolong the life of the device), clear the screen and close
         resources associated with the underlying serial interface.
 
+        If self.persist is True, the device will not be switched off.
+
         This is a managed function, which is called when the python processs
         is being shutdown, so shouldn't usually need be called directly in
         application code.
         """
-        self.hide()
-        self.clear()
+        if not self.persist:
+            self.hide()
+            self.clear()
         self._serial_interface.cleanup()
 
 

--- a/luma/core/mixin.py
+++ b/luma/core/mixin.py
@@ -36,6 +36,7 @@ class capabilities(object):
         self.bounding_box = (0, 0, self.width - 1, self.height - 1)
         self.rotate = rotate
         self.mode = mode
+        self.persist = False
 
     def clear(self):
         """

--- a/tests/test_persist.py
+++ b/tests/test_persist.py
@@ -4,8 +4,7 @@
 # See LICENSE.rst for details.
 
 
-from helpers import Mock, call, patch
-import pytest
+from helpers import patch
 
 from luma.core.device import dummy
 

--- a/tests/test_persist.py
+++ b/tests/test_persist.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2017-18 Richard Hull and contributors
+# See LICENSE.rst for details.
+
+
+from helpers import Mock, call, patch
+import pytest
+
+from luma.core.device import dummy
+
+
+def test_persist():
+    dev = dummy()
+    assert dev.persist is False
+    with patch.object(dev, 'hide') as mock:
+        dev.cleanup()
+    mock.assert_called_once_with()
+    dev = dummy()
+    dev.persist = True
+    with patch.object(dev, 'hide') as mock:
+        dev.cleanup()
+    mock.assert_not_called()

--- a/tests/test_persist.py
+++ b/tests/test_persist.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2017-18 Richard Hull and contributors
+# Copyright (c) 2018 Richard Hull and contributors
 # See LICENSE.rst for details.
 
 


### PR DESCRIPTION
Added a "persist" member to capabilities, to keep track of whether to leave the display on upon exit or clear it.
It will have to be set manually on the device variable:

```python
serial = spi(port=0, device=0, gpio=noop())
device = max7219(serial, cascaded=1)
device.persist = True
seg = sevensegment(device)
seg.text = "Hello Pi"
```
