### PR TITLE
Exclude font definitions from autodoc; add docstring table instead

### DIFF
--- a/doc/api-documentation.rst
+++ b/doc/api-documentation.rst
@@ -57,6 +57,7 @@ API Documentation
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: CP437_FONT, SINCLAIR_FONT, LCD_FONT, UKR_FONT, TINY_FONT,SEG7_FONT
 
 :mod:`luma.core.mixin`
 """"""""""""""""""""""

--- a/luma/core/legacy/font.py
+++ b/luma/core/legacy/font.py
@@ -3,7 +3,30 @@
 # See LICENSE.rst for details.
 
 """
-Fixed-width font definitions
+Fixed-width font definitions. The following fonts are available:
+
++-------------------+-------------------------------------------------+-----------------------------------------------------------------------------------------------+
+| Font name         | Notes                                           | Source                                                                                        |
++===================+=================================================+===============================================================================================+
+| ``CP437_FONT``    | See https://en.wikipedia.org/wiki/Code_page_437 | *unascribed*                                                                                  |
+|                   | for further details.                            |                                                                                               |
++-------------------+-------------------------------------------------+-----------------------------------------------------------------------------------------------+
+| ``LCD_FONT``      | Only contains characters 0x20-0x7F inclusive    | http://www.avrfreaks.net/forum/code-57-512-and-712-fonts?name=PNphpBB2&file=viewtopic&t=69880 |
+|                   | and Cyrillic chars 0x80-0xBF (except 'Ёё');     |                                                                                               |
+|                   | all others will appear as blanks.               |                                                                                               |
++-------------------+-------------------------------------------------+-----------------------------------------------------------------------------------------------+
+| ``SEG7_FONT``     | Only contains characters 0x41-0x5A & 0x30-0x39  | https://www.dafont.com/digital-7.font                                                         |
+|                   | inclusive; all others will appear as blanks.    |                                                                                               |
++-------------------+-------------------------------------------------+-----------------------------------------------------------------------------------------------+
+| ``SINCLAIR_FONT`` | Based on the character set from the Sinclair ZX | http://www.henningkarlsen.com/electronics/r_fonts.php                                         |
+|                   | Spectrum.  Only contains characters 0x20-0x7E   |                                                                                               |
+|                   | inclusive; all others will appear as blanks.    |                                                                                               |
++-------------------+-------------------------------------------------+-----------------------------------------------------------------------------------------------+
+| ``TINY_FONT``     | Only contains characters 0x20-0x7E inclusive;   | http://www.dafont.com/tiny.font                                                               |
+|                   | all others will appear as blanks.               |                                                                                               |
++-------------------+-------------------------------------------------+-----------------------------------------------------------------------------------------------+
+| ``UKR_FONT``      | Cyrillic Ukrainian font                         | *unascribed*                                                                                  |
++-------------------+-------------------------------------------------+-----------------------------------------------------------------------------------------------+
 """
 
 


### PR DESCRIPTION
@thijstriemstra - didn't see what you had in #132 that fixes #131 - furthermore I didn't see #132 at all until just now...  in any regard, I excluded the members and added a docstring table:

<img width="839" alt="screen shot 2018-03-29 at 21 14 41" src="https://user-images.githubusercontent.com/1915543/38111376-a4fc97ea-3396-11e8-9bd9-f95465b2b54f.png">
