### PR TITLE
Namespace packaging fix

### DIFF
--- a/luma/__init__.py
+++ b/luma/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2014-18 Richard Hull and contributors
+# Copyright (c) 2017-18 Richard Hull and contributors
 # See LICENSE.rst for details.
 
 try:

--- a/luma/__init__.py
+++ b/luma/__init__.py
@@ -2,6 +2,12 @@
 # Copyright (c) 2017-18 Richard Hull and contributors
 # See LICENSE.rst for details.
 
+# declare_namespace(__name__) is required for setup.py to build a package
+# that correctly specifies "luma" in both "packages" and "namespace_packages"
+# Normally just adding "luma" as a regular package would suffice, but since
+# the namespace packages use a period "." they share a parent directory under
+# some circumstances and this file will be deleted when any one package is
+# uninstalled- breaking any remaining packages that share the "luma" directory.
 try:
     from pkg_resources import declare_namespace
     declare_namespace(__name__)

--- a/luma/__init__.py
+++ b/luma/__init__.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2017-18 Richard Hull and contributors
+# Copyright (c) 2014-18 Richard Hull and contributors
 # See LICENSE.rst for details.
 
-from pkgutil import extend_path
-__path__ = extend_path(__path__, __name__)
+try:
+    from pkg_resources import declare_namespace
+    declare_namespace(__name__)
+except ImportError:
+    from pkgutil import extend_path
+    __path__ = extend_path(__path__, __name__)

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
     keywords="raspberry orange banana pi rpi opi sbc oled lcd led display screen spi i2c",
     url="https://github.com/rm-hull/luma.core",
     download_url="https://github.com/rm-hull/luma.core/tarball/" + version,
+    namespace_packages=["luma"],
     packages=["luma", "luma.core", "luma.core.legacy", "luma.core.interface"],
     install_requires=install_deps,
     setup_requires=pytest_runner,


### PR DESCRIPTION
Tweak of #145 based on extensive investigation described here: https://github.com/rm-hull/luma.oled/pull/215

The `declare_namespace(__name___)` addition to `__init__.py` avoids a quirk of `setup.py/setuptools` where it will complain about namespace packages that do not include this directive, despite the `pkg_resources` approach being discouraged.

My best evidence for the reliability of this pattern is that Google use it: https://github.com/google/protobuf/blob/master/python/google/__init__.py

https://github.com/google/protobuf/blob/bdcbcabe5e123067ad2474994df343d0458b63ea/python/setup.py#L252-L257
