### PR TITLE
Add support for using any GPIO pin as a CS pin

### DIFF
--- a/luma/core/interface/serial.py
+++ b/luma/core/interface/serial.py
@@ -280,9 +280,9 @@ class spi(bitbang):
             self._spi.open(port, device)
             self._spi.cshigh = cs_high
             if gpio_CS:
-                self._spi.no_cs = True # disable spidev's handling of the chip select pin
+                self._spi.no_cs = True  # disable spidev's handling of the chip select pin
                 self._cs_high = cs_high
-                
+
         except (IOError, OSError) as e:
             if e.errno == errno.ENOENT:
                 raise luma.core.error.DeviceNotFoundError('SPI device not found')
@@ -295,9 +295,9 @@ class spi(bitbang):
         gpio = self._gpio
         if self._CE:
             gpio.output(self._CE, gpio.HIGH if self._cs_high else gpio.LOW)
-        
+
         self._spi.writebytes(data)
-        
+
         if self._CE:
             gpio.output(self._CE, gpio.LOW if self._cs_high else gpio.HIGH)
 

--- a/luma/core/interface/serial.py
+++ b/luma/core/interface/serial.py
@@ -309,7 +309,8 @@ class gpio_cs_spi(spi):
     :param gpio_CS: The GPIO pin to connect chip select (CS / CE) to (defaults to None).
     :type gpio_CS: int
     """
-    def __init__(self, *args, gpio_CS=None, **kwargs):
+    def __init__(self, *args, **kwargs):
+        gpio_CS = kwargs.pop("gpio_CS", None)  # Python 2.7 doesn't allow var args and default values at the same time
         super().__init__(*args, **kwargs)
 
         if gpio_CS:

--- a/luma/core/interface/serial.py
+++ b/luma/core/interface/serial.py
@@ -311,7 +311,7 @@ class gpio_cs_spi(spi):
     """
     def __init__(self, *args, **kwargs):
         gpio_CS = kwargs.pop("gpio_CS", None)  # Python 2.7 doesn't allow var args and default values at the same time
-        super().__init__(*args, **kwargs)
+        super(gpio_cs_spi, self).__init__(*args, **kwargs)
 
         if gpio_CS:
             self._gpio_CS = gpio_CS
@@ -322,7 +322,7 @@ class gpio_cs_spi(spi):
         if self._gpio_CS:
             self._gpio.output(self._gpio_CS, self._gpio.HIGH if self._spi.cshigh else self._gpio.LOW)
 
-        super()._write_bytes(*args, **kwargs)
+        super(gpio_cs_spi, self)._write_bytes(*args, **kwargs)
 
         if self._gpio_CS:
             self._gpio.output(self._gpio_CS, self._gpio.LOW if self._spi.cshigh else self._gpio.HIGH)

--- a/luma/core/interface/serial.py
+++ b/luma/core/interface/serial.py
@@ -265,12 +265,14 @@ class spi(bitbang):
     :type gpio_DC: int
     :param gpio_RST: The GPIO pin to connect reset (RES / RST) to (defaults to 25).
     :type gpio_RST: int
+    :param gpio_CS: The GPIO pin to connect chip select (CS / CE) to (defaults to None).
+    :type gpio_CS: int
     :raises luma.core.error.DeviceNotFoundError: SPI device could not be found.
     :raises luma.core.error.UnsupportedPlatform: GPIO access not available.
     """
     def __init__(self, spi=None, gpio=None, port=0, device=0,
                  bus_speed_hz=8000000, cs_high=False, transfer_size=4096,
-                 gpio_CS=None, gpio_DC=24, gpio_RST=25):
+                 gpio_DC=24, gpio_RST=25, gpio_CS=None):
         assert(bus_speed_hz in [mhz * 1000000 for mhz in [0.5, 1, 2, 4, 8, 16, 32]])
 
         bitbang.__init__(self, gpio, transfer_size, CE=gpio_CS, DC=gpio_DC, RST=gpio_RST)

--- a/tests/test_gpio_cs_spi.py
+++ b/tests/test_gpio_cs_spi.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2017-18 Richard Hull and contributors
+# Copyright (c) 2017-20 Richard Hull and contributors
 # See LICENSE.rst for details.
 
 """
-Tests for the :py:class:`luma.core.interface.serial.spi` class.
+Tests for the :py:class:`luma.core.interface.serial.gpio_cs_spi` class.
 """
 
 import pytest
 
-from luma.core.interface.serial import spi
+from luma.core.interface.serial import gpio_cs_spi
 import luma.core.error
 
 from helpers import Mock, call, get_spidev, rpi_gpio_missing, fib
@@ -30,11 +30,11 @@ def setup_function(function):
     gpio.LOW = 6
 
 
-def verify_spi_init(port, device, bus_speed_hz=8000000, dc=24, rst=25):
+def verify_gpio_cs_spi_init(port, device, bus_speed_hz=8000000, dc=24, rst=25, cs=23):
     spidev.open.assert_called_once_with(port, device)
     assert spidev.max_speed_hz == bus_speed_hz
     gpio.setmode.assert_not_called()
-    gpio.setup.assert_has_calls([call(dc, gpio.OUT), call(rst, gpio.OUT)])
+    gpio.setup.assert_has_calls([call(dc, gpio.OUT), call(rst, gpio.OUT), call(cs, gpio.OUT, initial=gpio.HIGH)])
 
 
 def test_init():
@@ -43,10 +43,11 @@ def test_init():
     bus_speed = 16000000
     dc = 17
     rst = 11
+    cs = 23
 
-    spi(gpio=gpio, spi=spidev, port=port, device=device, bus_speed_hz=16000000,
-        gpio_DC=dc, gpio_RST=rst)
-    verify_spi_init(port, device, bus_speed, dc, rst)
+    gpio_cs_spi(gpio=gpio, spi=spidev, port=port, device=device, bus_speed_hz=16000000,
+        gpio_DC=dc, gpio_RST=rst, gpio_CS=cs)
+    verify_gpio_cs_spi_init(port, device, bus_speed, dc, rst, cs)
     gpio.output.assert_has_calls([
         call(rst, gpio.LOW),
         call(rst, gpio.HIGH)
@@ -55,32 +56,32 @@ def test_init():
 
 def test_init_invalid_bus_speed():
     with pytest.raises(AssertionError):
-        spi(gpio=gpio, spi=spidev, port=5, device=2, bus_speed_hz=942312)
+        gpio_cs_spi(gpio=gpio, spi=spidev, port=5, device=2, bus_speed_hz=942312, gpio_CS=23)
 
 
 def test_command():
     cmds = [3, 1, 4, 2]
-    serial = spi(gpio=gpio, spi=spidev, port=9, device=1)
+    serial = gpio_cs_spi(gpio=gpio, spi=spidev, port=9, device=1, gpio_CS=23)
     serial.command(*cmds)
-    verify_spi_init(9, 1)
-    gpio.output.assert_has_calls([call(25, gpio.HIGH), call(24, gpio.LOW)])
+    verify_gpio_cs_spi_init(9, 1)
+    gpio.output.assert_has_calls([call(25, gpio.HIGH), call(24, gpio.LOW), call(23, gpio.LOW), call(23, gpio.HIGH)])
     spidev.writebytes.assert_called_once_with(cmds)
 
 
 def test_data():
     data = list(fib(100))
-    serial = spi(gpio=gpio, spi=spidev, port=9, device=1)
+    serial = gpio_cs_spi(gpio=gpio, spi=spidev, port=9, device=1, gpio_CS=23)
     serial.data(data)
-    verify_spi_init(9, 1)
-    gpio.output.assert_has_calls([call(25, gpio.HIGH), call(24, gpio.HIGH)])
+    verify_gpio_cs_spi_init(9, 1)
+    gpio.output.assert_has_calls([call(25, gpio.HIGH), call(24, gpio.HIGH), call(23, gpio.LOW), call(23, gpio.HIGH)])
     spidev.writebytes.assert_called_once_with(data)
 
 
 def test_cleanup():
-    serial = spi(gpio=gpio, spi=spidev, port=9, device=1)
+    serial = gpio_cs_spi(gpio=gpio, spi=spidev, port=9, device=1, gpio_CS=23)
     serial._managed = True
     serial.cleanup()
-    verify_spi_init(9, 1)
+    verify_gpio_cs_spi_init(9, 1)
     spidev.close.assert_called_once_with()
     gpio.cleanup.assert_called_once_with()
 
@@ -89,13 +90,13 @@ def test_init_device_not_found():
     spidev = get_spidev()
     port = 1234
     with pytest.raises(luma.core.error.DeviceNotFoundError) as ex:
-        spi(gpio=gpio, spi=spidev.SpiDev(), port=port)
+        gpio_cs_spi(gpio=gpio, spi=spidev.SpiDev(), port=port, gpio_CS=23)
     assert str(ex.value) == 'SPI device not found'
 
 
 def test_unsupported_gpio_platform():
     try:
-        spi(spi=spidev, port=9, device=1)
+        gpio_cs_spi(spi=spidev, port=9, device=1, gpio_CS=23)
     except luma.core.error.UnsupportedPlatform as ex:
         assert str(ex) == 'GPIO access not available'
     except ImportError:

--- a/tests/test_spi.py
+++ b/tests/test_spi.py
@@ -78,7 +78,7 @@ def test_command_with_custom_cs():
     cmds = [3, 1, 4, 2]
     serial = spi(gpio=gpio, spi=spidev, port=9, device=1, gpio_CS=23)
     serial.command(*cmds)
-    verify_spi_init(9, 1)
+    verify_spi_init_with_custom_cs(9, 1)
     gpio.output.assert_has_calls([call(25, gpio.HIGH), call(24, gpio.LOW), call(23, gpio.LOW)])
     spidev.writebytes.assert_called_once_with(cmds)
     gpio.output.assert_has_calls([call(23, gpio.HIGH)])
@@ -97,7 +97,7 @@ def test_data_with_custom_cs():
     data = list(fib(100))
     serial = spi(gpio=gpio, spi=spidev, port=9, device=1, gpio_CS=23)
     serial.data(data)
-    verify_spi_init(9, 1)
+    verify_spi_init_with_custom_cs(9, 1)
     gpio.output.assert_has_calls([call(25, gpio.HIGH), call(24, gpio.HIGH), call(23, gpio.LOW)])
     spidev.writebytes.assert_called_once_with(data)
     gpio.output.assert_has_calls([call(23, gpio.HIGH)])

--- a/tests/test_spi.py
+++ b/tests/test_spi.py
@@ -36,11 +36,13 @@ def verify_spi_init(port, device, bus_speed_hz=8000000, dc=24, rst=25):
     gpio.setmode.assert_not_called()
     gpio.setup.assert_has_calls([call(dc, gpio.OUT), call(rst, gpio.OUT)])
 
+
 def verify_spi_init_with_custom_cs(port, device, bus_speed_hz=8000000, dc=24, rst=25, cs=23):
     spidev.open.assert_called_once_with(port, device)
     assert spidev.max_speed_hz == bus_speed_hz
     gpio.setmode.assert_not_called()
     gpio.setup.assert_has_calls([call(cs, gpio.OUT), call(dc, gpio.OUT), call(rst, gpio.OUT)])
+
 
 def test_init():
     port = 5
@@ -57,6 +59,7 @@ def test_init():
         call(rst, gpio.HIGH)
     ])
 
+
 def test_init_invalid_bus_speed():
     with pytest.raises(AssertionError):
         spi(gpio=gpio, spi=spidev, port=5, device=2, bus_speed_hz=942312)
@@ -70,6 +73,7 @@ def test_command():
     gpio.output.assert_has_calls([call(25, gpio.HIGH), call(24, gpio.LOW)])
     spidev.writebytes.assert_called_once_with(cmds)
 
+
 def test_command_with_custom_cs():
     cmds = [3, 1, 4, 2]
     serial = spi(gpio=gpio, spi=spidev, port=9, device=1, gpio_CS=23)
@@ -79,6 +83,7 @@ def test_command_with_custom_cs():
     spidev.writebytes.assert_called_once_with(cmds)
     gpio.output.assert_has_calls([call(23, gpio.HIGH)])
 
+
 def test_data():
     data = list(fib(100))
     serial = spi(gpio=gpio, spi=spidev, port=9, device=1)
@@ -86,6 +91,7 @@ def test_data():
     verify_spi_init(9, 1)
     gpio.output.assert_has_calls([call(25, gpio.HIGH), call(24, gpio.HIGH)])
     spidev.writebytes.assert_called_once_with(data)
+
 
 def test_data_with_custom_cs():
     data = list(fib(100))
@@ -95,6 +101,7 @@ def test_data_with_custom_cs():
     gpio.output.assert_has_calls([call(25, gpio.HIGH), call(24, gpio.HIGH), call(23, gpio.LOW)])
     spidev.writebytes.assert_called_once_with(data)
     gpio.output.assert_has_calls([call(23, gpio.HIGH)])
+
 
 def test_cleanup():
     serial = spi(gpio=gpio, spi=spidev, port=9, device=1)

--- a/tests/test_spi.py
+++ b/tests/test_spi.py
@@ -36,6 +36,11 @@ def verify_spi_init(port, device, bus_speed_hz=8000000, dc=24, rst=25):
     gpio.setmode.assert_not_called()
     gpio.setup.assert_has_calls([call(dc, gpio.OUT), call(rst, gpio.OUT)])
 
+def verify_spi_init_with_custom_cs(port, device, bus_speed_hz=8000000, dc=24, rst=25, cs=23):
+    spidev.open.assert_called_once_with(port, device)
+    assert spidev.max_speed_hz == bus_speed_hz
+    gpio.setmode.assert_not_called()
+    gpio.setup.assert_has_calls([call(cs, gpio.OUT), call(dc, gpio.OUT), call(rst, gpio.OUT)])
 
 def test_init():
     port = 5
@@ -52,7 +57,6 @@ def test_init():
         call(rst, gpio.HIGH)
     ])
 
-
 def test_init_invalid_bus_speed():
     with pytest.raises(AssertionError):
         spi(gpio=gpio, spi=spidev, port=5, device=2, bus_speed_hz=942312)
@@ -66,6 +70,14 @@ def test_command():
     gpio.output.assert_has_calls([call(25, gpio.HIGH), call(24, gpio.LOW)])
     spidev.writebytes.assert_called_once_with(cmds)
 
+def test_command_with_custom_cs():
+    cmds = [3, 1, 4, 2]
+    serial = spi(gpio=gpio, spi=spidev, port=9, device=1, gpio_CS=23)
+    serial.command(*cmds)
+    verify_spi_init(9, 1)
+    gpio.output.assert_has_calls([call(25, gpio.HIGH), call(24, gpio.LOW), call(23, gpio.LOW)])
+    spidev.writebytes.assert_called_once_with(cmds)
+    gpio.output.assert_has_calls([call(23, gpio.HIGH)])
 
 def test_data():
     data = list(fib(100))
@@ -75,6 +87,14 @@ def test_data():
     gpio.output.assert_has_calls([call(25, gpio.HIGH), call(24, gpio.HIGH)])
     spidev.writebytes.assert_called_once_with(data)
 
+def test_data_with_custom_cs():
+    data = list(fib(100))
+    serial = spi(gpio=gpio, spi=spidev, port=9, device=1, gpio_CS=23)
+    serial.data(data)
+    verify_spi_init(9, 1)
+    gpio.output.assert_has_calls([call(25, gpio.HIGH), call(24, gpio.HIGH), call(23, gpio.LOW)])
+    spidev.writebytes.assert_called_once_with(data)
+    gpio.output.assert_has_calls([call(23, gpio.HIGH)])
 
 def test_cleanup():
     serial = spi(gpio=gpio, spi=spidev, port=9, device=1)


### PR DESCRIPTION
fixes #170

There seems to be a bug with spidev where it ignores the `no_cs` option: https://github.com/doceme/py-spidev/issues/46

Besides that, I've tested it locally with 3 screens on a single `(port, device)` and it works as expected.