### PR TITLE
Elide python 2.7 from setup & project infra

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,5 @@
 python:
-   version: 2.7
+   version: 3.6
    pip_install: true
    extra_requirements:
        - docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ cache: pip
 
 matrix:
     include:
-        - python: 2.7
-          env: TOXENV=py27
         - python: 3.5
           env: TOXENV=py35
         - python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ matrix:
           env: TOXENV=py36
         - python: 3.7
           env: TOXENV=py37
-        - python: 3.8-dev
+        - python: 3.8
           env: TOXENV=py38
         - python: 3.5
           env: TOXENV=qa,doc
 
 install: pip install --ignore-installed --upgrade setuptools pip tox coveralls
 script: tox -vv
-after_success: if [ "$TOXENV" == "py36" ]; then coveralls; fi
+after_success: if [ "$TOXENV" == "py38" ]; then coveralls; fi

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Luma.Core
 .. image:: https://img.shields.io/maintenance/yes/2020.svg?maxAge=2592000
 
 **luma.core** is a component library providing a `Pillow <https://pillow.readthedocs.io/>`_-compatible
-drawing canvas, and other functionality to support drawing primitives and
+drawing canvas for Python 3, and other functionality to support drawing primitives and
 text-rendering capabilities for small displays on the Raspberry Pi and other
 single board computers:
 

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -1,7 +1,7 @@
 Introduction
 ------------
 **luma.core** is a component library providing a Pillow-compatible drawing
-canvas, and other functionality to support drawing primitives and
+canvas for Python 3, and other functionality to support drawing primitives and
 text-rendering capabilities for small displays on the Raspberry Pi and other
 single board computers:
 

--- a/luma/core/sprite_system.py
+++ b/luma/core/sprite_system.py
@@ -10,11 +10,6 @@ Simplified sprite animation framework.
 """
 
 import time
-try:
-    monotonic = time.monotonic
-except AttributeError:  # pragma: no cover
-    from monotonic import monotonic
-
 from PIL import Image
 
 
@@ -188,7 +183,7 @@ class framerate_regulator(object):
         self.last_time = None
 
     def __enter__(self):
-        self.enter_time = monotonic()
+        self.enter_time = time.monotonic()
         if not self.start_time:
             self.start_time = self.enter_time
             self.last_time = self.enter_time
@@ -203,15 +198,15 @@ class framerate_regulator(object):
         it simply exits without blocking.
         """
         self.called += 1
-        self.total_transit_time += monotonic() - self.enter_time
+        self.total_transit_time += time.monotonic() - self.enter_time
         if self.max_sleep_time >= 0:
-            elapsed = monotonic() - self.last_time
+            elapsed = time.monotonic() - self.last_time
             sleep_for = self.max_sleep_time - elapsed
 
             if sleep_for > 0:
                 time.sleep(sleep_for)
 
-        self.last_time = monotonic()
+        self.last_time = time.monotonic()
 
     def effective_FPS(self):
         """
@@ -224,7 +219,7 @@ class framerate_regulator(object):
         """
         if self.start_time is None:
             self.start_time = 0
-        elapsed = monotonic() - self.start_time
+        elapsed = time.monotonic() - self.start_time
         return self.called / elapsed
 
     def average_transit_time(self):

--- a/luma/core/virtual.py
+++ b/luma/core/virtual.py
@@ -4,10 +4,6 @@
 
 import time
 from textwrap import TextWrapper
-try:
-    monotonic = time.monotonic
-except AttributeError:  # pragma: no cover
-    from monotonic import monotonic
 
 from PIL import Image, ImageDraw, ImageFont
 
@@ -202,11 +198,11 @@ class snapshot(hotspot):
         """
         Only requests a redraw after ``interval`` seconds have elapsed.
         """
-        return monotonic() - self.last_updated > self.interval
+        return time.monotonic() - self.last_updated > self.interval
 
     def paste_into(self, image, xy):
         super(snapshot, self).paste_into(image, xy)
-        self.last_updated = monotonic()
+        self.last_updated = time.monotonic()
 
 
 class terminal(object):

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ project_url = "https://github.com/rm-hull/luma.core"
 needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
 pytest_runner = ['pytest-runner'] if needs_pytest else []
 test_deps = [
-    "pytest",
+    "pytest==4.5",
     "pytest-cov"
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -30,15 +30,14 @@ project_url = "https://github.com/rm-hull/luma.core"
 needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
 pytest_runner = ['pytest-runner'] if needs_pytest else []
 test_deps = [
-    'mock;python_version<"3.3"',
-    "pytest==4.5",
+    "pytest",
     "pytest-cov"
 ]
 
 install_deps = [
     'pillow>=4.0.0',
     'smbus2',
-    'pyftdi;python_version>="3.5"'
+    'pyftdi'
 ]
 
 setup(
@@ -49,7 +48,7 @@ setup(
     description=("A component library to support SBC display drivers"),
     long_description="\n\n".join([README, CONTRIB, CHANGES]),
     long_description_content_type="text/x-rst",
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4',
+    python_requires='>=3.5, <4',
     license="MIT",
     keywords="raspberry orange banana pi rpi opi sbc oled lcd led display screen spi i2c ftdi usb",
     url=project_url,
@@ -67,9 +66,6 @@ setup(
     extras_require={
         ':platform_system=="Linux"': [
             'spidev', 'RPI.GPIO'
-        ],
-        ':python_version<"3.3"': [
-            'monotonic'
         ],
         'docs': [
             'sphinx>=1.5.1'
@@ -89,8 +85,6 @@ setup(
         "Topic :: Education",
         "Topic :: System :: Hardware",
         "Topic :: System :: Hardware :: Hardware Drivers",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -17,7 +17,6 @@ rpi_gpio_missing = 'RPi.GPIO is not supported on this platform: {}'.format(
     platform.system())
 spidev_missing = 'spidev is not supported on this platform: {}'.format(
     platform.system())
-pyftdi_missing = 'pyftdi is not supported on Python {}'.format(platform.python_version())
 
 
 def get_reference_file(fname):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -8,8 +8,6 @@ Test helpers.
 
 import os.path
 import platform
-from unittest.mock import patch, call, Mock
-
 import pytest
 
 from PIL import ImageChops, ImageFont

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -8,11 +8,7 @@ Test helpers.
 
 import os.path
 import platform
-
-try:
-    from unittest.mock import patch, call, Mock
-except ImportError:
-    from mock import patch, call, Mock  # noqa: F401
+from unittest.mock import patch, call, Mock
 
 import pytest
 

--- a/tests/test_bitbang.py
+++ b/tests/test_bitbang.py
@@ -7,12 +7,13 @@
 Tests for the :py:class:`luma.core.interface.serial.bitbang` class.
 """
 
+from unittest.mock import Mock, call
 from luma.core.interface.serial import bitbang
 import luma.core.error
 
 import pytest
 
-from helpers import Mock, call, rpi_gpio_missing
+from helpers import rpi_gpio_missing
 
 
 gpio = Mock(unsafe=True)

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -10,11 +10,12 @@ Tests for the :py:mod:`luma.core.cmdline` module.
 import pytest
 import errno
 import sys
+from unittest.mock import patch, Mock
 
 from luma.core import cmdline, error
 from luma.core.interface.serial import __all__ as iface_types
 
-from helpers import (get_reference_file, patch, Mock, i2c_error,
+from helpers import (get_reference_file, i2c_error,
     rpi_gpio_missing, spidev_missing, pyftdi_missing)
 
 

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -16,7 +16,7 @@ from luma.core import cmdline, error
 from luma.core.interface.serial import __all__ as iface_types
 
 from helpers import (get_reference_file, i2c_error,
-    rpi_gpio_missing, spidev_missing, pyftdi_missing)
+    rpi_gpio_missing, spidev_missing)
 
 
 test_config_file = get_reference_file('config-test.txt')
@@ -289,7 +289,6 @@ def test_create_device_emulator():
         assert device == display_name
 
 
-@pytest.mark.skipif(sys.version_info < (3, 5), reason=pyftdi_missing)
 @patch('pyftdi.spi.SpiController')
 def test_make_serial_ftdi_spi(mock_controller):
     """
@@ -305,7 +304,6 @@ def test_make_serial_ftdi_spi(mock_controller):
     assert 'luma.core.interface.serial.spi' in repr(factory.ftdi_spi())
 
 
-@pytest.mark.skipif(sys.version_info < (3, 5), reason=pyftdi_missing)
 @patch('pyftdi.i2c.I2cController')
 def test_make_serial_ftdi_i2c(mock_controller):
     """

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -9,7 +9,6 @@ Tests for the :py:mod:`luma.core.cmdline` module.
 
 import pytest
 import errno
-import sys
 from unittest.mock import patch, Mock
 
 from luma.core import cmdline, error

--- a/tests/test_framerate_regulator.py
+++ b/tests/test_framerate_regulator.py
@@ -8,10 +8,6 @@ Tests for the :py:class:`luma.core.sprite_system.framerate_regulator` class.
 """
 
 import time
-try:
-    monotonic = time.monotonic
-except AttributeError:
-    from monotonic import monotonic
 from luma.core.sprite_system import framerate_regulator
 
 
@@ -20,10 +16,10 @@ def test_init_default():
     assert regulator.start_time is None
     assert regulator.last_time is None
     assert regulator.called == 0
-    before = monotonic()
+    before = time.monotonic()
     with regulator:
         pass
-    after = monotonic()
+    after = time.monotonic()
 
     assert regulator.max_sleep_time == 1 / 16.67
     assert before <= regulator.start_time <= after
@@ -32,10 +28,10 @@ def test_init_default():
 
 def test_init_unlimited():
     regulator = framerate_regulator(fps=0)
-    before = monotonic()
+    before = time.monotonic()
     with regulator:
         pass
-    after = monotonic()
+    after = time.monotonic()
 
     assert regulator.max_sleep_time == -1
     assert before <= regulator.start_time <= after
@@ -44,10 +40,10 @@ def test_init_unlimited():
 
 def test_init_30fps():
     regulator = framerate_regulator(fps=30)
-    before = monotonic()
+    before = time.monotonic()
     with regulator:
         pass
-    after = monotonic()
+    after = time.monotonic()
 
     assert regulator.max_sleep_time == 1 / 30.00
     assert before <= regulator.start_time <= after
@@ -56,11 +52,11 @@ def test_init_30fps():
 
 def test_sleep():
     regulator = framerate_regulator(fps=100.00)
-    before = monotonic()
+    before = time.monotonic()
     for _ in range(200):
         with regulator:
             pass
-    after = monotonic()
+    after = time.monotonic()
 
     assert regulator.called == 200
     assert after - before >= 2.0

--- a/tests/test_ftdi_i2c.py
+++ b/tests/test_ftdi_i2c.py
@@ -8,7 +8,6 @@ Tests for the :py:class:`luma.core.interface.serial.ftdi_i2c` class.
 """
 
 import pytest
-import sys
 from unittest.mock import Mock, patch
 from luma.core.interface.serial import ftdi_i2c
 from helpers import fib

--- a/tests/test_ftdi_i2c.py
+++ b/tests/test_ftdi_i2c.py
@@ -11,11 +11,10 @@ import pytest
 import sys
 from unittest.mock import Mock, patch
 from luma.core.interface.serial import ftdi_i2c
-from helpers import pyftdi_missing, fib
+from helpers import fib
 import luma.core.error
 
 
-@pytest.mark.skipif(sys.version_info < (3, 5), reason=pyftdi_missing)
 @patch('pyftdi.i2c.I2cController')
 def test_init(mock_controller):
     instance = Mock()
@@ -28,7 +27,6 @@ def test_init(mock_controller):
     instance.get_port.assert_called_with(0xFF)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 5), reason=pyftdi_missing)
 @patch('pyftdi.i2c.I2cController')
 def test_command(mock_controller):
     cmds = [3, 1, 4, 2]
@@ -42,7 +40,6 @@ def test_command(mock_controller):
     port.write_to.assert_called_once_with(0x00, cmds)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 5), reason=pyftdi_missing)
 @patch('pyftdi.i2c.I2cController')
 def test_data(mock_controller):
     data = list(fib(100))
@@ -56,7 +53,6 @@ def test_data(mock_controller):
     port.write_to.assert_called_once_with(0x40, data)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 5), reason=pyftdi_missing)
 @patch('pyftdi.i2c.I2cController')
 def test_cleanup(mock_controller):
     port = Mock()
@@ -69,7 +65,6 @@ def test_cleanup(mock_controller):
     instance.terminate.assert_called_once_with()
 
 
-@pytest.mark.skipif(sys.version_info < (3, 5), reason=pyftdi_missing)
 @patch('pyftdi.i2c.I2cController')
 def test_init_device_address_error(mock_controller):
     address = 'foo'

--- a/tests/test_ftdi_i2c.py
+++ b/tests/test_ftdi_i2c.py
@@ -9,8 +9,9 @@ Tests for the :py:class:`luma.core.interface.serial.ftdi_i2c` class.
 
 import pytest
 import sys
+from unittest.mock import Mock, patch
 from luma.core.interface.serial import ftdi_i2c
-from helpers import Mock, patch, pyftdi_missing, fib
+from helpers import pyftdi_missing, fib
 import luma.core.error
 
 

--- a/tests/test_ftdi_spi.py
+++ b/tests/test_ftdi_spi.py
@@ -11,10 +11,9 @@ import pytest
 from unittest.mock import Mock, call, patch
 import sys
 from luma.core.interface.serial import ftdi_spi
-from helpers import pyftdi_missing, fib
+from helpers import fib
 
 
-@pytest.mark.skipif(sys.version_info < (3, 5), reason=pyftdi_missing)
 @patch('pyftdi.spi.SpiController')
 def test_init(mock_controller):
     gpio = Mock()
@@ -31,7 +30,6 @@ def test_init(mock_controller):
     gpio.set_direction.assert_called_with(0x60, 0x60)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 5), reason=pyftdi_missing)
 @patch('pyftdi.spi.SpiController')
 def test_command(mock_controller):
     cmds = [3, 1, 4, 2]
@@ -48,7 +46,6 @@ def test_command(mock_controller):
     port.write.assert_called_once_with(cmds)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 5), reason=pyftdi_missing)
 @patch('pyftdi.spi.SpiController')
 def test_data(mock_controller):
     data = list(fib(100))
@@ -65,7 +62,6 @@ def test_data(mock_controller):
     port.write.assert_called_once_with(data)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 5), reason=pyftdi_missing)
 @patch('pyftdi.spi.SpiController')
 def test_cleanup(mock_controller):
     gpio = Mock()

--- a/tests/test_ftdi_spi.py
+++ b/tests/test_ftdi_spi.py
@@ -8,9 +8,10 @@ Tests for the :py:class:`luma.core.interface.serial.ftdi_spi` class.
 """
 
 import pytest
+from unittest.mock import Mock, call, patch
 import sys
 from luma.core.interface.serial import ftdi_spi
-from helpers import Mock, call, patch, pyftdi_missing, fib
+from helpers import pyftdi_missing, fib
 
 
 @pytest.mark.skipif(sys.version_info < (3, 5), reason=pyftdi_missing)

--- a/tests/test_ftdi_spi.py
+++ b/tests/test_ftdi_spi.py
@@ -7,9 +7,7 @@
 Tests for the :py:class:`luma.core.interface.serial.ftdi_spi` class.
 """
 
-import pytest
 from unittest.mock import Mock, call, patch
-import sys
 from luma.core.interface.serial import ftdi_spi
 from helpers import fib
 

--- a/tests/test_gpio_cs_spi.py
+++ b/tests/test_gpio_cs_spi.py
@@ -8,11 +8,12 @@ Tests for the :py:class:`luma.core.interface.serial.gpio_cs_spi` class.
 """
 
 import pytest
+from unittest.mock import Mock, call
 
 from luma.core.interface.serial import gpio_cs_spi
 import luma.core.error
 
-from helpers import Mock, call, get_spidev, rpi_gpio_missing, fib
+from helpers import get_spidev, rpi_gpio_missing, fib
 
 
 spidev = Mock(unsafe=True)

--- a/tests/test_i2c.py
+++ b/tests/test_i2c.py
@@ -10,10 +10,11 @@ Tests for the :py:class:`luma.core.interface.serial.i2c` class.
 import errno
 import pytest
 import smbus2
+from unittest.mock import Mock, patch, call
 from luma.core.interface.serial import i2c
 import luma.core.error
 
-from helpers import Mock, patch, call, i2c_error, fib
+from helpers import i2c_error, fib
 
 
 smbus = Mock(unsafe=True)

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -7,7 +7,7 @@ from luma.core.device import dummy
 from luma.core.legacy import text, textsize, show_message
 from luma.core.legacy.font import proportional, CP437_FONT, LCD_FONT
 
-from helpers import Mock, call
+from unittest.mock import Mock, call
 
 
 def test_textsize():

--- a/tests/test_legacy_fonts.py
+++ b/tests/test_legacy_fonts.py
@@ -14,7 +14,6 @@ from luma.core.legacy import text, textsize
 import luma.core.legacy.font
 from luma.core.legacy.font import proportional
 
-
 import pytest
 from helpers import get_reference_image, assert_identical_image
 

--- a/tests/test_persist.py
+++ b/tests/test_persist.py
@@ -4,7 +4,7 @@
 # See LICENSE.rst for details.
 
 
-from helpers import patch
+from unittest.mock import patch
 
 from luma.core.device import dummy
 

--- a/tests/test_spi.py
+++ b/tests/test_spi.py
@@ -8,11 +8,12 @@ Tests for the :py:class:`luma.core.interface.serial.spi` class.
 """
 
 import pytest
+from unittest.mock import Mock, call
 
 from luma.core.interface.serial import spi
 import luma.core.error
 
-from helpers import Mock, call, get_spidev, rpi_gpio_missing, fib
+from helpers import get_spidev, rpi_gpio_missing, fib
 
 
 spidev = Mock(unsafe=True)

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # See LICENSE.rst for details.
 
 [tox]
-envlist = py{27,35,36,37,38},qa,doc
+envlist = py{35,36,37,38},qa,doc
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Not sure why we cant use latest pytest (as per 1st commit) - not really had chance to look into this failure: https://travis-ci.org/rm-hull/luma.core/builds/656037029