### PR TITLE
snapshot: always redraw first should_redraw

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -30,3 +30,4 @@ Contributors
 * Daniel Smullen (@drspangle)
 * Hans Liss (@hansliss)
 * Phil Howard (@gadgetoid)
+* Manuel Baesler (@baslr)

--- a/luma/core/virtual.py
+++ b/luma/core/virtual.py
@@ -190,19 +190,15 @@ class snapshot(hotspot):
     updates.
     """
     def __init__(self, width, height, draw_fn=None, interval=1.0):
+        assert interval > 0
         super(snapshot, self).__init__(width, height, draw_fn)
         self.interval = interval
-        self.last_updated = 0.0
-        self.first_redraw = True
+        self.last_updated = -interval
 
     def should_redraw(self):
         """
         Only requests a redraw after ``interval`` seconds have elapsed.
         """
-        if self.first_redraw is True:
-            self.first_redraw = False
-            return True
-
         return time.monotonic() - self.last_updated > self.interval
 
     def paste_into(self, image, xy):

--- a/luma/core/virtual.py
+++ b/luma/core/virtual.py
@@ -193,11 +193,16 @@ class snapshot(hotspot):
         super(snapshot, self).__init__(width, height, draw_fn)
         self.interval = interval
         self.last_updated = 0.0
+        self.first_redraw = True
 
     def should_redraw(self):
         """
         Only requests a redraw after ``interval`` seconds have elapsed.
         """
+        if self.first_redraw is True:
+            self.first_redraw = False
+            return True
+
         return time.monotonic() - self.last_updated > self.interval
 
     def paste_into(self, image, xy):

--- a/tests/test_viewport.py
+++ b/tests/test_viewport.py
@@ -96,7 +96,7 @@ def test_snapshot_last_updated():
         assert width == 10
 
     sshot = snapshot(10, 10, draw_fn, interval)
-    assert sshot.last_updated == 0.0
+    assert sshot.last_updated == -interval
     assert sshot.should_redraw() is True
     sshot.paste_into(Image.new("RGB", (10, 10)), (0, 0))
     assert sshot.should_redraw() is False


### PR DESCRIPTION
If you have a snapshot with interval 60 seconds and the software runs immediately after system start the first redraw does not happen.
```
#           20 - 0 > 60 is false
return time.monotonic() - self.last_updated > self.interval
```