### PR TITLE
Allow reset to be held active for a configurable duration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ ChangeLog
 | Version    | Description                                                         | Date       |
 +============+=====================================================================+============+
 | *TBC*      | * Added --inverse option for ST7735 to cmdline opt                  | TBC        |
+|            | * Allow SPI interface to define reset duration                      |            |
 +------------+---------------------------------------------------------------------+------------+
 | **1.16.2** | * Added new parallel interface module                               | 2020/09/20 |
 |            | * Renamed parallel class to bitbang_6800; moved to parallel module  |            |

--- a/luma/core/cmdline.py
+++ b/luma/core/cmdline.py
@@ -156,6 +156,7 @@ class make_serial(object):
                    cs_high=self.opts.spi_cs_high,
                    transfer_size=self.opts.spi_transfer_size,
                    reset_hold_time=self.opts.gpio_reset_hold_time,
+                   reset_release_time=self.opts.gpio_reset_release_time,
                    gpio_DC=self.opts.gpio_data_command,
                    gpio_RST=self.opts.gpio_reset,
                    gpio=self.gpio or GPIO)
@@ -261,6 +262,7 @@ def create_parser(description):
     gpio_group.add_argument('--gpio-reset', type=int, default=25, help='GPIO pin for RESET (SPI devices only)')
     gpio_group.add_argument('--gpio-backlight', type=int, default=18, help='GPIO pin for backlight (PCD8544, ST7735 devices only)')
     gpio_group.add_argument('--gpio-reset-hold-time', type=float, default=0, help='Duration to hold reset line active on startup (seconds) (SPI devices only)')
+    gpio_group.add_argument('--gpio-reset-release-time', type=float, default=0, help='Duration to pause for after reset line was made active on startup (seconds) (SPI devices only)')
 
     misc_group = parser.add_argument_group('Misc')
     misc_group.add_argument('--block-orientation', type=int, default=0, help='Fix 90° phase error (MAX7219 LED matrix only). Allowed values are: {0}'.format(', '.join([str(x) for x in block_orientation_choices])), choices=block_orientation_choices, metavar='ORIENTATION')

--- a/luma/core/cmdline.py
+++ b/luma/core/cmdline.py
@@ -155,6 +155,7 @@ class make_serial(object):
                    bus_speed_hz=self.opts.spi_bus_speed,
                    cs_high=self.opts.spi_cs_high,
                    transfer_size=self.opts.spi_transfer_size,
+                   reset_hold_time=self.opts.gpio_reset_hold_time,
                    gpio_DC=self.opts.gpio_data_command,
                    gpio_RST=self.opts.gpio_reset,
                    gpio=self.gpio or GPIO)
@@ -259,6 +260,7 @@ def create_parser(description):
     gpio_group.add_argument('--gpio-data-command', type=int, default=24, help='GPIO pin for D/C RESET (SPI devices only)')
     gpio_group.add_argument('--gpio-reset', type=int, default=25, help='GPIO pin for RESET (SPI devices only)')
     gpio_group.add_argument('--gpio-backlight', type=int, default=18, help='GPIO pin for backlight (PCD8544, ST7735 devices only)')
+    gpio_group.add_argument('--gpio-reset-hold-time', type=float, default=0, help='Duration to hold reset line active on startup (seconds) (SPI devices only)')
 
     misc_group = parser.add_argument_group('Misc')
     misc_group.add_argument('--block-orientation', type=int, default=0, help='Fix 90° phase error (MAX7219 LED matrix only). Allowed values are: {0}'.format(', '.join([str(x) for x in block_orientation_choices])), choices=block_orientation_choices, metavar='ORIENTATION')

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -30,6 +30,7 @@ class test_spi_opts(object):
     gpio_data_command = 24
     gpio_reset = 25
     gpio_backlight = 18
+    gpio_reset_hold_time = 0
 
     interface = 'spi'
 

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -31,6 +31,7 @@ class test_spi_opts(object):
     gpio_reset = 25
     gpio_backlight = 18
     gpio_reset_hold_time = 0
+    gpio_reset_release_time = 0
 
     interface = 'spi'
 


### PR DESCRIPTION
Fixes #187 

Provides an optional parameter (and cmd-line switch) to prolong the reset hold duration. It seems like some devices need the reset line to be kept active for a minimum period.

Usage would be like:
```python
serial = spi(device=0, port=0, reset_hold_time=0.1)  # 100ms
device = st7735(serial)
```

If the parameter is not provided, existing behaviour is not changed.