### PR TITLE
Legacy proportional font wrapper raises user-friendly error message when character is not in the font table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ ChangeLog
 +============+=====================================================================+============+
 | *TBC*      | * Drop support for Python 3.5, only 3.6 or newer is supported now   |            |
 |            | * Add missing cmdline interfaces: "noop" & "gpio_cs_spi"            |            |
+|            | * Legacy proportional font wrapper raises user-friendly error       |            |
+|            |   message when character is not in the font table                   |            |
 +------------+---------------------------------------------------------------------+------------+
 | **1.17.2** | * Remove SPI cs_high capability (causing SystemException in latest  | 2020/09/11 |
 |            |   version of spidev on 5.4 kernel line)                             |            |

--- a/luma/core/legacy/font.py
+++ b/luma/core/legacy/font.py
@@ -49,7 +49,7 @@ class proportional(object):
             else:
                 return self._trim(bitmap) + [0]
         except IndexError:
-            raise IndexError("Font does not have ASCII code: {ascii_code}")
+            raise IndexError(f"Font does not have ASCII code: {ascii_code}")
 
     def _trim(self, arr):
         nonzero = [idx for idx, val in enumerate(arr) if val != 0]

--- a/luma/core/legacy/font.py
+++ b/luma/core/legacy/font.py
@@ -41,12 +41,15 @@ class proportional(object):
         self.font = font
 
     def __getitem__(self, ascii_code):
-        bitmap = self.font[ascii_code]
-        # Return a slim version of the space character
-        if ascii_code == 32:
-            return [0] * 4
-        else:
-            return self._trim(bitmap) + [0]
+        try:
+            bitmap = self.font[ascii_code]
+            # Return a slim version of the space character
+            if ascii_code == 32:
+                return [0] * 4
+            else:
+                return self._trim(bitmap) + [0]
+        except IndexError:
+            raise IndexError("Font does not have ASCII code: {ascii_code}")
 
     def _trim(self, arr):
         nonzero = [idx for idx, val in enumerate(arr) if val != 0]

--- a/tests/test_proportional.py
+++ b/tests/test_proportional.py
@@ -33,8 +33,9 @@ def test_trim_not_nonzero():
     font = proportional(CP437_FONT)
     assert font._trim([0, 0, 0, 0]) == []
 
+
 def test_unicode_not_supported():
     font = proportional(CP437_FONT)
     with pytest.raises(IndexError) as ex:
         font[ord("😀")]
-        assert str(ex.value) == 'Font does not have ASCII code: 123'
+    assert str(ex.value) == 'Font does not have ASCII code: 128512'

--- a/tests/test_proportional.py
+++ b/tests/test_proportional.py
@@ -4,6 +4,8 @@
 # See LICENSE.rst for details.
 
 
+import pytest
+
 from luma.core.legacy.font import proportional, CP437_FONT
 
 
@@ -30,3 +32,9 @@ def test_doublequote_char():
 def test_trim_not_nonzero():
     font = proportional(CP437_FONT)
     assert font._trim([0, 0, 0, 0]) == []
+
+def test_unicode_not_supported():
+    font = proportional(CP437_FONT)
+    with pytest.raises(IndexError) as ex:
+        font[ord("😀")]
+        assert str(ex.value) == 'Font does not have ASCII code: 123'


### PR DESCRIPTION
Fixes https://github.com/rm-hull/luma.led_matrix/issues/237