### PR TITLE
Fix to allow cmdline args to dynamically create a full_frame() instance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ ChangeLog
 +------------+---------------------------------------------------------------------+------------+
 | Version    | Description                                                         | Date       |
 +============+=====================================================================+============+
+| **2.0.1**  | * Fix to allow cmdline args to dynamically create a full_frame()    | TBC        |
+|            |   instance                                                          |            |
++------------+---------------------------------------------------------------------+------------+
 | **2.0.0**  | * Improved diff_to_previous framebuffer performance                 | 2020/11/02 |
 |            | * Add Linux framebuffer pseudo-device                               |            |
 |            | * Allow a wider range of SPI bus speeds                             |            |

--- a/luma/core/framebuffer.py
+++ b/luma/core/framebuffer.py
@@ -106,6 +106,11 @@ class full_frame(object):
     this is provided as a drop-in replacement.
     """
 
+    def __init__(self, **kwargs):
+        """
+        Accepts any args but does nothing
+        """
+
     def redraw(self, image):
         """
         Yields the full image for every redraw.


### PR DESCRIPTION
Without this, running any of the examples causes a failure when running with the `--framebuffer=full_frame` flag, as per below:

```console
$ python3 examples/bounce.py -f conf/ssd1331.conf --framebuffer=full_frame
Traceback (most recent call last):
  File "examples/bounce.py", line 80, in <module>
    device = get_device()
  File "/home/rhu/dev/luma.examples/examples/demo_opts.py", line 61, in get_device
    device = cmdline.create_device(args)
  File "/usr/local/lib/python3.7/dist-packages/luma/core/cmdline.py", line 242, in create_device
    framebuffer = getattr(luma.core.framebuffer, args.framebuffer)(num_segments=args.num_segments, debug=args.debug)
TypeError: full_frame() takes no arguments
```