### PR TITLE
tests: do not match exact OS errno strings

### DIFF
--- a/tests/test_bitmap_font.py
+++ b/tests/test_bitmap_font.py
@@ -234,7 +234,7 @@ def test_load_sprite_table_exceptions_1():
     with pytest.raises(FileNotFoundError) as ex:
         filename = 'badfile'
         bitmap_font.load_sprite_table(filename, range(16, 256), 5, (5, 8), (5, 8), FONTDATA['mappings'][1])
-    assert str(ex.value) == f'[Errno 2] No such file or directory: \'{filename}\''
+    assert ex.value.filename == filename
 
 
 def test_load_sprite_table_exceptions_2():


### PR DESCRIPTION
The actual string representation of an errno (like `ENOENT`) is an OS implementation detail, and there is no guarantee on it. Also, we are already checking that the exception is `FileNotFoundError`, which implies `ENOENT` already.

Hence, simplify the assertion checking: check that the actual filename that triggered the exception was the wrong one that was passed to `load_sprite_table()`.