### PR TITLE
don't use parentheses for assert statements

### DIFF
--- a/contrib/tca9548a_scan.py
+++ b/contrib/tca9548a_scan.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2017-18 Richard Hull and contributors
+# Copyright (c) 2017-2022 Richard Hull and contributors
 # See LICENSE.rst for details.
 
 """
@@ -16,7 +16,7 @@ TCA_ADDR = 0x70
 
 
 def mux_select(bus, tca_port):
-    assert(0 <= tca_port <= 7)
+    assert 0 <= tca_port <= 7
     bus.write_byte(TCA_ADDR, 1 << tca_port)
 
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2017-2021 Richard Hull and contributors
+# Copyright (c) 2017-2022 Richard Hull and contributors
 # See LICENSE.rst for details.
 
 # luma.core documentation build configuration file, created by
@@ -80,7 +80,7 @@ release = version
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/luma/core/image_composition.py
+++ b/luma/core/image_composition.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2017-18 Richard Hull and contributors
+# Copyright (c) 2017-2022 Richard Hull and contributors
 # See LICENSE.rst for details.
 
 """
@@ -30,7 +30,7 @@ class ComposableImage(object):
             from which it should be drawn.
         :type offset: tuple
         """
-        assert(image)
+        assert image
         self._image = image
         self._position = position
         self._offset = offset
@@ -104,8 +104,8 @@ class ComposableImage(object):
             by ``size``.
         :rtype: PIL.Image.Image
         """
-        assert(size[0])
-        assert(size[1])
+        assert size[0]
+        assert size[1]
         return self._image.crop(box=self._crop_box(size))
 
     def _crop_box(self, size):
@@ -147,7 +147,7 @@ class ImageComposition(object):
         :param image: The image to add.
         :type image: PIL.Image.Image
         """
-        assert(image)
+        assert image
         self.composed_images.append(image)
 
     def remove_image(self, image):
@@ -157,7 +157,7 @@ class ImageComposition(object):
         :param image: The image to be removed.
         :type image: PIL.Image.Image
         """
-        assert(image)
+        assert image
         self.composed_images.remove(image)
 
     def __call__(self):

--- a/luma/core/interface/serial.py
+++ b/luma/core/interface/serial.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2017-2021 Richard Hull and contributors
+# Copyright (c) 2017-2022 Richard Hull and contributors
 # See LICENSE.rst for details.
 
 """
@@ -90,7 +90,7 @@ class i2c(object):
         :type cmd: int
         :raises luma.core.error.DeviceNotFoundError: I2C device could not be found.
         """
-        assert(len(cmd) <= 32)
+        assert len(cmd) <= 32
 
         try:
             self._bus.write_i2c_block_data(self._addr, self._cmd_mode,
@@ -300,7 +300,7 @@ class spi(bitbang):
                  bus_speed_hz=8000000, transfer_size=4096,
                  gpio_DC=24, gpio_RST=25, spi_mode=None,
                  reset_hold_time=0, reset_release_time=0, **kwargs):
-        assert(bus_speed_hz in [mhz * 1000000 for mhz in [0.5, 1, 2, 4, 8, 16, 20, 24, 28, 32, 36, 40, 44, 48, 50, 52]])
+        assert bus_speed_hz in [mhz * 1000000 for mhz in [0.5, 1, 2, 4, 8, 16, 20, 24, 28, 32, 36, 40, 44, 48, 50, 52]]
 
         bitbang.__init__(self, gpio, transfer_size, reset_hold_time, reset_release_time, DC=gpio_DC, RST=gpio_RST)
 

--- a/luma/core/render.py
+++ b/luma/core/render.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2017-18 Richard Hull and contributors
+# Copyright (c) 2017-2022 Richard Hull and contributors
 # See LICENSE.rst for details.
 
 from PIL import Image, ImageDraw
@@ -24,7 +24,7 @@ class canvas(object):
         if background is None:
             self.image = Image.new("RGB" if dither else device.mode, device.size)
         else:
-            assert(background.size == device.size)
+            assert background.size == device.size
             self.image = background.copy()
         self.device = device
         self.dither = dither

--- a/luma/core/sprite_system.py
+++ b/luma/core/sprite_system.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2017-2020 Richard Hull and contributors
+# Copyright (c) 2017-2022 Richard Hull and contributors
 # See LICENSE.rst for details.
 
 """
@@ -77,8 +77,8 @@ class spritesheet(object):
         self.image = self.image.crop((regX, regY, self.image.width - regX, self.image.height - regY))
         self.width, self.height = self.image.size
 
-        assert(self.width % self.frames.width == 0)
-        assert(self.height % self.frames.height == 0)
+        assert self.width % self.frames.width == 0
+        assert self.height % self.frames.height == 0
 
         self.frames.size = (self.frames.width, self.frames.height)
         if not hasattr(self.frames, 'count'):

--- a/luma/core/virtual.py
+++ b/luma/core/virtual.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2017-2020 Richard Hull and contributors
+# Copyright (c) 2017-2022 Richard Hull and contributors
 # See LICENSE.rst for details.
 
 from textwrap import TextWrapper
@@ -64,8 +64,8 @@ class viewport(mixin.capabilities):
         self._dither = dither
 
     def display(self, image):
-        assert(image.mode == self.mode)
-        assert(image.size == self.size)
+        assert image.mode == self.mode
+        assert image.size == self.size
 
         self._backing_image.paste(image)
         self.refresh()
@@ -81,8 +81,8 @@ class viewport(mixin.capabilities):
         raised.
         """
         (x, y) = xy
-        assert(0 <= x <= self.width - hotspot.width)
-        assert(0 <= y <= self.height - hotspot.height)
+        assert 0 <= x <= self.width - hotspot.width
+        assert 0 <= y <= self.height - hotspot.height
 
         # TODO: should it check to see whether hotspots overlap each other?
         # Is sensible to _allow_ them to overlap?
@@ -132,8 +132,8 @@ class viewport(mixin.capabilities):
         right = left + self._device.width
         bottom = top + self._device.height
 
-        assert(0 <= left <= right <= self.width)
-        assert(0 <= top <= bottom <= self.height)
+        assert 0 <= left <= right <= self.width
+        assert 0 <= top <= bottom <= self.height
 
         return (left, top, right, bottom)
 
@@ -473,7 +473,7 @@ class history(mixin.capabilities):
         :param drop:
         :type drop: int
         """
-        assert(drop >= 0)
+        assert drop >= 0
         while drop > 0:
             self._savepoints.pop()
             drop -= 1

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ setenv =
     PYTHONDEVMODE=1
 commands =
     coverage erase
-    python setup.py install
     py.test --cov=luma {posargs}
     coverage html
 deps = .[test]


### PR DESCRIPTION
See https://realpython.com/python-assert-statement/

> Even though the parentheses seem to work in the scenario described in the above example, it’s not a recommended practice. You can end up shooting yourself in the foot.