### PR TITLE
Raspberry Pi 5 Support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ zip_safe = False
 packages = find_namespace:
 python_requires = >=3.7, <4
 install_requires =
+    gpiozero
     pillow>=9.2.0
     smbus2
     pyftdi


### PR DESCRIPTION
This is a fork of a fork (https://github.com/outdoorbits/luma.core) in hopes to add RPi 5 support to luma.core