### PR TITLE
remove usage of OrderedDict

### DIFF
--- a/luma/core/cmdline.py
+++ b/luma/core/cmdline.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2017-2022 Richard Hull and contributors
+# Copyright (c) 2017-2024 Richard Hull and contributors
 # See LICENSE.rst for details.
 
 import atexit
 import inspect
 import argparse
 import importlib
-from collections import OrderedDict
 
 
 def get_choices(module_name):
@@ -86,9 +85,9 @@ def get_display_types():
     Get ordered dict containing available display types from available luma
     sub-projects.
 
-    :rtype: collections.OrderedDict
+    :rtype: dict
     """
-    display_types = OrderedDict()
+    display_types = dict()
     for namespace in get_supported_libraries():
         display_types[namespace] = get_choices(f'luma.{namespace}.device')
 

--- a/luma/core/cmdline.py
+++ b/luma/core/cmdline.py
@@ -82,7 +82,7 @@ def get_interface_types():
 
 def get_display_types():
     """
-    Get ordered dict containing available display types from available luma
+    Get ``dict`` containing available display types from available luma
     sub-projects.
 
     :rtype: dict

--- a/tests/test_bitmap_font.py
+++ b/tests/test_bitmap_font.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2020 Richard Hull and contributors
+# Copyright (c) 2020-2024 Richard Hull and contributors
 # See LICENSE.rst for details.
 
 """
@@ -234,7 +234,7 @@ def test_load_sprite_table_exceptions_1():
     with pytest.raises(FileNotFoundError) as ex:
         filename = 'badfile'
         bitmap_font.load_sprite_table(filename, range(16, 256), 5, (5, 8), (5, 8), FONTDATA['mappings'][1])
-    assert ex.value.filename == filename
+    assert Path(ex.value.filename).stem == filename
 
 
 def test_load_sprite_table_exceptions_2():


### PR DESCRIPTION
dict gained the [ability to remember insertion order in py3.7](https://docs.python.org/3.8/library/collections.html#ordereddict-objects), so this OrderedDict usage isn't needed any longer