### PR TITLE
Make GPIO/SPI/FTDI optional and switch to rpi-lgpio

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,15 @@ jobs:
         run: python -c "import sys; print(sys.version)"
       - name: Install Python packages
         run: pip install --upgrade setuptools pip wheel tox coveralls
+      - name: Install system dependencies
+        run: sudo apt-get install swig python3-setuptools python3-dev
+      - name: Install lg library
+        run: |
+          wget http://abyz.me.uk/lg/lg.zip
+          unzip lg.zip
+          cd lg
+          make
+          sudo make install
       - name: Run tests
         env:
           TOX_ENV: py3${{ matrix.python-minor-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,7 @@ jobs:
         run: sudo apt-get install swig python3-setuptools python3-dev
       - name: Install lg library
         run: |
+          cd $RUNNER_TEMP
           wget http://abyz.me.uk/lg/lg.zip
           unzip lg.zip
           cd lg

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-minor-version: [8, 9, 10, 11, 12, 13, 14-dev]
+        python-minor-version: [8, 9, 10, 11, 12, 13]
     name: Python 3.${{ matrix.python-minor-version }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,12 +12,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-minor-version: [8, 9, 10, 11, 12, 13-dev]
+        python-minor-version: [8, 9, 10, 11, 12, 13, 14-dev]
     name: Python 3.${{ matrix.python-minor-version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup pip cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: pipcache
         with:
           path: ~/.cache/pip
@@ -25,7 +25,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-v2-
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         id: setuppy
         with:
           python-version: 3.${{ matrix.python-minor-version }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -13,11 +13,11 @@ jobs:
     name: Build and publish Python package
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Install pypa/build
         run: |
           python -m pip install --upgrade setuptools pip wheel twine

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ ChangeLog
 | Version    | Description                                                         | Date       |
 +============+=====================================================================+============+
 | **2.5.0**  | * Drop support for Python 3.7                                       | TBD        |
+|            | * GPIO/SPI/FTDI dependencies are optional now and no longer         |            |
+|            |   installed by default (use pip install luma.core[gpio] instead)    |            |
+|            | * Switch from RPI.GPIO to rpi-lgpio for RPI5 support                |            |
 +------------+---------------------------------------------------------------------+------------+
 | **2.4.2**  | * Add support for spi-mode in cmdline                               | 2024/01/30 |
 +------------+---------------------------------------------------------------------+------------+

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,10 +31,7 @@ python_requires = >=3.8, <4
 install_requires =
     pillow>=9.2.0
     smbus2
-    pyftdi
     cbor2
-    RPI.GPIO; platform_system=="Linux"
-    spidev; platform_system=="Linux"
 tests_require =
     pytest
     pytest-cov
@@ -45,6 +42,12 @@ tests_require =
 include = luma*
 
 [options.extras_require]
+gpio =
+    RPI.GPIO; platform_system=="Linux"
+spi =
+    spidev; platform_system=="Linux"
+ftdi =
+    pyftdi
 docs =
     sphinx>=1.5.1
     sphinx-rtd-theme

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ include = luma*
 
 [options.extras_require]
 gpio =
-    RPI.GPIO; platform_system=="Linux"
+    rpi-lgpio; platform_system=="Linux"
 spi =
     spidev; platform_system=="Linux"
 ftdi =

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2017-2021 Richard Hull and contributors
+# Copyright (c) 2017-2024 Richard Hull and contributors
 # See LICENSE.rst for details.
 
 """
@@ -191,7 +191,7 @@ def test_make_interface_spi():
     except ImportError:
         # non-rpi platform, e.g. macos
         pytest.skip(rpi_gpio_missing)
-    except error.UnsupportedPlatform as e:
+    except (error.UnsupportedPlatform, error.DeviceNotFoundError) as e:
         # non-rpi platform, e.g. ubuntu 64-bit
         skip_unsupported_platform(e)
 
@@ -211,7 +211,7 @@ def test_make_interface_gpio_cs_spi():
     except ImportError:
         # non-rpi platform, e.g. macos
         pytest.skip(rpi_gpio_missing)
-    except error.UnsupportedPlatform as e:
+    except (error.UnsupportedPlatform, error.DeviceNotFoundError) as e:
         # non-rpi platform, e.g. ubuntu 64-bit
         skip_unsupported_platform(e)
 
@@ -341,7 +341,7 @@ def test_create_device_oled():
             assert device == display_name
         except ImportError:
             pytest.skip(rpi_gpio_missing)
-        except error.UnsupportedPlatform as e:
+        except (error.UnsupportedPlatform, error.DeviceNotFoundError) as e:
             # non-rpi platform
             skip_unsupported_platform(e)
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,11 @@ commands =
     coverage erase
     py.test --cov=luma {posargs}
     coverage html
-deps = .[test]
+deps =
+    .[gpio]
+    .[spi]
+    .[ftdi]
+    .[test]
 
 [testenv:watch]  # use ptw (=pytestwatch) to run tests when files change
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # See LICENSE.rst for details.
 
 [tox]
-envlist = py{38,39,310,311,312,313},qa,doc
+envlist = py{38,39,310,311,312,313,314},qa,doc
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
fixes #270 

to install optional dependencies:

- GPIO : `pip install luma.core[gpio]`
- SPI: `pip install luma.core[spi]`
- FTDI: `pip install luma.core[ftdi]`