### PR TITLE
Remove deprecated entries from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,6 @@ author_email = richard.hull@destructuring-bind.org
 url = https://github.com/rm-hull/luma.core
 license = MIT
 classifiers =
-    License :: OSI Approved :: MIT License
     Development Status :: 5 - Production/Stable
     Intended Audience :: Education
     Intended Audience :: Developers
@@ -59,9 +58,6 @@ test =
     pytest-cov
     pytest-timeout
     pytest-watch
-
-[bdist_wheel]
-universal = 1
 
 [flake8]
 ignore = E121, E122, E124, E125, E127, E128, E241, E402, E501, E731, E722


### PR DESCRIPTION
License classifiers are deprecated in favor of SPDX license expressions.

With Python 2.7 end-of-life, support for building universal wheels is being removed.