### PR TITLE
Raise UnsupportedPlatform for any RPi.GPIO RuntimeError, not just known messages

### DIFF
--- a/luma/core/lib.py
+++ b/luma/core/lib.py
@@ -23,11 +23,9 @@ def __rpi_gpio__(self):
         import RPi.GPIO as GPIO
         GPIO.setmode(GPIO.BCM)
         return GPIO
-    except RuntimeError as e:
-        if str(e) in ['This module can only be run on a Raspberry Pi!',
-                      'Module not imported correctly!']:
-            raise luma.core.error.UnsupportedPlatform(
-                'GPIO access not available')
+    except RuntimeError:
+        raise luma.core.error.UnsupportedPlatform(
+            'GPIO access not available')
 
 
 def rpi_gpio(Class):

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -4,6 +4,12 @@
 # See LICENSE.rst for details.
 
 
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+import luma.core.error
 from luma.core.lib import spidev, rpi_gpio
 
 
@@ -42,3 +48,15 @@ def test_multi():
     t = MultiLibTest()
     for method in ['__spidev__', '__rpi_gpio__']:
         assertMethod(t, method)
+
+
+def test_rpi_gpio_unrecognized_runtime_error(monkeypatch):
+    fake_gpio = Mock(unsafe=True)
+    fake_gpio.setmode.side_effect = RuntimeError('some other platform-specific message')
+    fake_rpi = Mock(GPIO=fake_gpio)
+    monkeypatch.setitem(sys.modules, 'RPi', fake_rpi)
+    monkeypatch.setitem(sys.modules, 'RPi.GPIO', fake_gpio)
+
+    t = RpiGpioTest()
+    with pytest.raises(luma.core.error.UnsupportedPlatform):
+        t.__rpi_gpio__()


### PR DESCRIPTION
__rpi_gpio__ only converts the RuntimeError from RPi.GPIO into UnsupportedPlatform when the message is one of two hardcoded strings. Any other RuntimeError (different RPi.GPIO version, different wording, running without root, etc) falls through the except block and the function returns None instead of raising, so callers end up with self._gpio being None and later crash with a confusing AttributeError instead of the intended UnsupportedPlatform. Reported against luma.lcd (rm-hull/luma.lcd#200) where the None _gpio crash surfaces, but the fix belongs here. Added a test covering an unrecognized RuntimeError message.